### PR TITLE
Add Country CRUD with Thymeleaf and H2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,26 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/vibecoding/VibeCodingApplication.java
+++ b/src/main/java/com/vibecoding/VibeCodingApplication.java
@@ -1,0 +1,12 @@
+package com.vibecoding;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class VibeCodingApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(VibeCodingApplication.class, args);
+    }
+}

--- a/src/main/java/com/vibecoding/controller/CountryController.java
+++ b/src/main/java/com/vibecoding/controller/CountryController.java
@@ -1,0 +1,63 @@
+package com.vibecoding.controller;
+
+import com.vibecoding.model.Country;
+import com.vibecoding.service.CountryService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/countries")
+public class CountryController {
+
+    private final CountryService countryService;
+
+    public CountryController(CountryService countryService) {
+        this.countryService = countryService;
+    }
+
+    @GetMapping
+    public String listCountries(Model model) {
+        model.addAttribute("countries", countryService.getAllCountries());
+        return "country-list";
+    }
+
+    @GetMapping("/new")
+    public String showCreateForm(Model model) {
+        model.addAttribute("country", new Country());
+        return "country-form";
+    }
+
+    @PostMapping
+    public String createCountry(@ModelAttribute Country country) {
+        countryService.saveCountry(country);
+        return "redirect:/countries";
+    }
+
+    @GetMapping("/edit/{id}")
+    public String showEditForm(@PathVariable Long id, Model model) {
+        Country country = countryService.getCountryById(id);
+        if (country == null) {
+            return "redirect:/countries";
+        }
+        model.addAttribute("country", country);
+        return "country-form";
+    }
+
+    @PostMapping("/update/{id}")
+    public String updateCountry(@PathVariable Long id, @ModelAttribute Country country) {
+        Country existing = countryService.getCountryById(id);
+        if (existing == null) {
+            return "redirect:/countries";
+        }
+        existing.setCountryName(country.getCountryName());
+        countryService.saveCountry(existing);
+        return "redirect:/countries";
+    }
+
+    @GetMapping("/delete/{id}")
+    public String deleteCountry(@PathVariable Long id) {
+        countryService.deleteCountry(id);
+        return "redirect:/countries";
+    }
+}

--- a/src/main/java/com/vibecoding/model/Country.java
+++ b/src/main/java/com/vibecoding/model/Country.java
@@ -1,0 +1,65 @@
+package com.vibecoding.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "countries")
+public class Country {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "country_name", nullable = false)
+    private String countryName;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCountryName() {
+        return countryName;
+    }
+
+    public void setCountryName(String countryName) {
+        this.countryName = countryName;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/vibecoding/repository/CountryRepository.java
+++ b/src/main/java/com/vibecoding/repository/CountryRepository.java
@@ -1,0 +1,7 @@
+package com.vibecoding.repository;
+
+import com.vibecoding.model.Country;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CountryRepository extends JpaRepository<Country, Long> {
+}

--- a/src/main/java/com/vibecoding/service/CountryService.java
+++ b/src/main/java/com/vibecoding/service/CountryService.java
@@ -1,0 +1,11 @@
+package com.vibecoding.service;
+
+import com.vibecoding.model.Country;
+import java.util.List;
+
+public interface CountryService {
+    List<Country> getAllCountries();
+    Country getCountryById(Long id);
+    Country saveCountry(Country country);
+    void deleteCountry(Long id);
+}

--- a/src/main/java/com/vibecoding/service/impl/CountryServiceImpl.java
+++ b/src/main/java/com/vibecoding/service/impl/CountryServiceImpl.java
@@ -1,0 +1,38 @@
+package com.vibecoding.service.impl;
+
+import com.vibecoding.model.Country;
+import com.vibecoding.repository.CountryRepository;
+import com.vibecoding.service.CountryService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CountryServiceImpl implements CountryService {
+
+    private final CountryRepository countryRepository;
+
+    public CountryServiceImpl(CountryRepository countryRepository) {
+        this.countryRepository = countryRepository;
+    }
+
+    @Override
+    public List<Country> getAllCountries() {
+        return countryRepository.findAll();
+    }
+
+    @Override
+    public Country getCountryById(Long id) {
+        return countryRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public Country saveCountry(Country country) {
+        return countryRepository.save(country);
+    }
+
+    @Override
+    public void deleteCountry(Long id) {
+        countryRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=vibe-coding
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:countriesdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.thymeleaf.cache=false

--- a/src/main/resources/templates/country-form.html
+++ b/src/main/resources/templates/country-form.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Country Form</title>
+</head>
+<body>
+<h1 th:text="${country.id} != null ? 'Edit Country' : 'Add Country'">Country Form</h1>
+<form th:action="${country.id} != null ? @{'/countries/update/' + ${country.id}} : @{/countries}" th:object="${country}" method="post">
+    <label for="countryName">Name:</label>
+    <input type="text" id="countryName" th:field="*{countryName}" />
+    <button type="submit">Save</button>
+</form>
+<a th:href="@{/countries}">Back to list</a>
+</body>
+</html>

--- a/src/main/resources/templates/country-list.html
+++ b/src/main/resources/templates/country-list.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Countries</title>
+</head>
+<body>
+<h1>Countries</h1>
+<a th:href="@{/countries/new}">Add Country</a>
+<table border="1">
+    <tr>
+        <th>ID</th>
+        <th>Name</th>
+        <th>Created At</th>
+        <th>Updated At</th>
+        <th>Actions</th>
+    </tr>
+    <tr th:each="country : ${countries}">
+        <td th:text="${country.id}">1</td>
+        <td th:text="${country.countryName}">Country</td>
+        <td th:text="${country.createdAt}">created</td>
+        <td th:text="${country.updatedAt}">updated</td>
+        <td>
+            <a th:href="@{'/countries/edit/' + ${country.id}}">Edit</a>
+            <a th:href="@{'/countries/delete/' + ${country.id}}">Delete</a>
+        </td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Country entity with timestamps and JPA annotations
- implement repository, service layer, and controller
- configure H2 database, JPA, and Thymeleaf with templates

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac247c3138832f87f1b0567ffc31a7